### PR TITLE
Add dry run option to update_mainline_kernel

### DIFF
--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -8,12 +8,15 @@ require 'shellwords'
 
 class CleanKernelPackages
 
-  def execute(dry_run: false, keep_previous: false, delete_current: false)
+  # include_versions: (Array of KernelVersion) act like the versions passed are installed; it's
+  #                   legal, but dangerous, to use this in a regular (non-dry) run.
+  #
+  def execute(dry_run: false, keep_previous: false, delete_current: false, include_versions: [])
     current_version = KernelVersion.find_current
 
     puts "Current kernel version: #{current_version}", ""
 
-    installed_versions = find_installed_versions(current_version)
+    installed_versions = find_installed_versions(current_version, include_versions: include_versions)
 
     puts "Currently installed package versions:", *installed_versions.map { |version| "- #{version}" }, ""
 
@@ -32,13 +35,15 @@ class CleanKernelPackages
 
   private
 
-  def find_installed_versions(current_version)
+  def find_installed_versions(current_version, include_versions: [])
     raw_packages_list = find_installed_packages("^linux-(headers|image|image-extra)-#{current_version.major}\\.#{current_version.minor}\\.")
 
     package_versions = raw_packages_list.map do |package_name|
       raw_version = package_name[/linux-\w+(-\w+)?-(\d+\.\d+\.\d+-\w+)/, 2] || raise("Version not identified: #{package_name}")
       KernelVersion.parse_version(raw_version)
     end
+
+    package_versions += include_versions
 
     # We catch both the linux-header and the linux-headers-generic, so we uniq them.
     #

--- a/update_mainline_kernel
+++ b/update_mainline_kernel
@@ -43,19 +43,21 @@ class UpdateMainlineKernel
   ARCHITECTURE = "amd64"
   DEFAULT_STORE_PATH = '/tmp'
 
-  def execute(install: nil, store_path: DEFAULT_STORE_PATH)
+  NO_ACTION_MESSAGE = 'NO ACTION: '
+
+  def execute(install: nil, dry_run: false, store_path: DEFAULT_STORE_PATH)
     case install
     when nil
       current_version = KernelVersion.find_current
-      install_latest_kernel_for_current_version(current_version, store_path)
+      install_latest_kernel_for_current_version(current_version, dry_run, store_path)
     when /^(\d+)\.(\d+)$/
       # Simulate the system having the earliest version (rc0, not existing) of the specified
       # version.
       select_version_rc0 = KernelVersion.new($1, $2, 0, rc: 0)
-      install_latest_kernel_for_current_version(select_version_rc0, store_path)
+      install_latest_kernel_for_current_version(select_version_rc0, dry_run, store_path)
     when /^(\d+)\.(\d+)\.(\d+)$/
       specific_version = KernelVersion.new($1, $2, $3)
-      install_specific_version(specific_version, store_path)
+      install_specific_version(specific_version, dry_run, store_path)
     else
       raise "Unexpected_version: #{install}"
     end
@@ -63,7 +65,7 @@ class UpdateMainlineKernel
 
   private
 
-  def install_latest_kernel_for_current_version(current_version, store_path)
+  def install_latest_kernel_for_current_version(current_version, dry_run, store_path)
     puts "Current kernel version: #{current_version}"
 
     mainline_ppa_page = load_mainline_ppa_page
@@ -75,8 +77,12 @@ class UpdateMainlineKernel
     installable_versions = all_patch_versions.select { |version| version > current_version }
 
     if installable_versions.size > 0
-      any_version_installed = install_latest_possible_version(installable_versions, store_path)
-      CleanKernelPackages.new.execute if any_version_installed
+      installed_version = install_latest_possible_version(installable_versions, dry_run, store_path)
+
+      if installed_version
+        cleaning_params = dry_run ? {dry_run: dry_run, include_versions: [installed_version]} : {}
+        CleanKernelPackages.new.execute(cleaning_params)
+      end
     else
       puts "Nothing to do."
     end
@@ -85,7 +91,7 @@ class UpdateMainlineKernel
   def install_specific_version(version, store_path)
     mainline_ppa_page = load_mainline_ppa_page
 
-    version_installed = install_version(version, store_path)
+    version_installed = install_version(version, dry_run, store_path)
 
     CleanKernelPackages.new.execute if version_installed
   end
@@ -110,17 +116,17 @@ class UpdateMainlineKernel
   # Tries to install the latest of the passed versions.
   # Returns true if any kernel was installed; false otherwise.
   #
-  def install_latest_possible_version(installable_versions, store_path)
+  def install_latest_possible_version(installable_versions, dry_run, store_path)
     installable_versions.sort.reverse.each do |installable_version|
-      version_installed = install_version(installable_version, store_path)
+      version_installed = install_version(installable_version, dry_run, store_path)
 
-      return true if version_installed
+      return installable_version if version_installed
     end
 
-    return false
+    return nil
   end
 
-  def install_version(version, store_path)
+  def install_version(version, dry_run, store_path)
     puts "Version: #{version}"
 
     puts "- finding package addresses..."
@@ -134,11 +140,11 @@ class UpdateMainlineKernel
     else
       puts "- downloading packages..."
 
-      package_files = download_package_files(package_addresses, store_path)
+      package_files = download_package_files(package_addresses, dry_run, store_path)
 
       puts "- installing packages..."
 
-      install_packages(package_files)
+      install_packages(package_files, dry_run)
 
       true
     end
@@ -181,20 +187,30 @@ class UpdateMainlineKernel
     end
   end
 
-  def download_package_files(package_addresses, destination_directory)
+  def download_package_files(package_addresses, dry_run, destination_directory)
     package_addresses.map do |package_address|
       file_basename = File.basename(package_address)
       destination_file = File.join(destination_directory, file_basename)
 
-      DownloadWithProgress.new.execute(package_address, destination_file)
+      if dry_run
+        puts "#{NO_ACTION_MESSAGE}downloading #{file_basename}..."
+      else
+        DownloadWithProgress.new.execute(package_address, destination_file)
+      end
 
       destination_file
     end
   end
 
-  def install_packages(package_files)
-    escaped_files_list = package_files.map { |filename| filename.shellescape }.join(' ')
-    `sudo dpkg -i #{escaped_files_list}`
+  def install_packages(package_files, dry_run)
+    if dry_run
+      package_files.each do |package_file|
+        puts "#{NO_ACTION_MESSAGE}installing #{package_file}..."
+      end
+    else
+      escaped_files_list = package_files.map { |filename| filename.shellescape }.join(' ')
+      `sudo dpkg -i #{escaped_files_list}`
+    end
   end
 
 end
@@ -209,6 +225,7 @@ if __FILE__ == $PROGRAM_NAME
 
   options = SimpleScripting::Argv.decode(
     ['-i', '--install VERSION', 'Install a certain version [format: <maj.min[.patch]>]'],
+    ['-n', '--dry-run',         "Don't perform download/installation"],
     ['-s', '--store-path PATH', 'Store packages to path (default: /tmp)'],
     long_help: long_help,
   ) || exit

--- a/update_mainline_kernel
+++ b/update_mainline_kernel
@@ -207,8 +207,8 @@ if __FILE__ == $PROGRAM_NAME
   HELP
 
   options = SimpleScripting::Argv.decode(
-    [ '-i', '--install VERSION', 'Install a certain version [format: <maj.min[.patch]>]' ],
-    [ '-s', '--store-path PATH', 'Store packages to path (default: /tmp)' ],
+    ['-i', '--install VERSION', 'Install a certain version [format: <maj.min[.patch]>]'],
+    ['-s', '--store-path PATH', 'Store packages to path (default: /tmp)'],
     long_help: long_help,
   ) || exit
 

--- a/update_mainline_kernel
+++ b/update_mainline_kernel
@@ -192,8 +192,9 @@ class UpdateMainlineKernel
     end
   end
 
-  def install_packages(downloaded_files)
-    `sudo dpkg -i #{downloaded_files.join(" ")}`
+  def install_packages(package_files)
+    escaped_files_list = package_files.map { |filename| filename.shellescape }.join(' ')
+    `sudo dpkg -i #{escaped_files_list}`
   end
 
 end

--- a/update_mainline_kernel
+++ b/update_mainline_kernel
@@ -130,7 +130,7 @@ class UpdateMainlineKernel
     if package_addresses.empty?
       puts "- build failed! skipping..."
 
-      return false
+      false
     else
       puts "- downloading packages..."
 
@@ -140,7 +140,7 @@ class UpdateMainlineKernel
 
       install_packages(package_files)
 
-      return true
+      true
     end
   end
 

--- a/update_mainline_kernel
+++ b/update_mainline_kernel
@@ -127,15 +127,15 @@ class UpdateMainlineKernel
 
     package_addresses = find_kernel_package_addresses(version)
 
-    puts "- downloading packages..."
-
-    package_files = download_package_files(package_addresses, store_path)
-
-    if package_files.empty?
+    if package_addresses.empty?
       puts "- build failed! skipping..."
 
       return false
     else
+      puts "- downloading packages..."
+
+      package_files = download_package_files(package_addresses, store_path)
+
       puts "- installing packages..."
 
       install_packages(package_files)

--- a/update_mainline_kernel
+++ b/update_mainline_kernel
@@ -43,10 +43,8 @@ class UpdateMainlineKernel
   ARCHITECTURE = "amd64"
   DEFAULT_STORE_PATH = '/tmp'
 
-  def execute(options = {})
-    store_path = options[:store_path] || DEFAULT_STORE_PATH
-
-    case options[:install]
+  def execute(install: nil, store_path: DEFAULT_STORE_PATH)
+    case install
     when nil
       current_version = KernelVersion.find_current
       install_latest_kernel_for_current_version(current_version, store_path)
@@ -59,7 +57,7 @@ class UpdateMainlineKernel
       specific_version = KernelVersion.new($1, $2, $3)
       install_specific_version(specific_version, store_path)
     else
-      raise "Unexpected_version: #{options[:install]}"
+      raise "Unexpected_version: #{install}"
     end
   end
 


### PR DESCRIPTION
Allow a run without changing the system; useful mostly in the case when one wants to check what's the latest version of new kernel.