### PR TITLE
update_mainline_kernel: use HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- 2018/Dec/15: `update_mainline_kernel`: use HTTPS
 - 2018/Nov/26: checker scripts: ownership fixes/improvements, and cosmetic improvements
 - 2018/Nov/19: `update_mainline_kernel`: add dry run mode
 - 2018/Nov/19: `clean_kernel_packages`: add support for including versions which are not actually installed

--- a/update_mainline_kernel
+++ b/update_mainline_kernel
@@ -15,7 +15,7 @@ class DownloadWithProgress
   def execute(address, destination_file)
     uri = URI(address)
 
-    Net::HTTP.start(uri.host) do |http|
+    Net::HTTP.start(uri.host, use_ssl: true) do |http|
       response = http.request_head(address)
 
       file_basename = File.basename(destination_file)
@@ -38,7 +38,7 @@ end
 
 class UpdateMainlineKernel
 
-  PPA_ADDRESS = "http://kernel.ubuntu.com/~kernel-ppa/mainline"
+  PPA_ADDRESS = "https://kernel.ubuntu.com/~kernel-ppa/mainline"
   KERNEL_TYPE = "generic"
   ARCHITECTURE = "amd64"
   DEFAULT_STORE_PATH = '/tmp'


### PR DESCRIPTION
HTTP addresses now redirect to HTTPS, so we use directly the latter (also avoids handling redirects).