### PR TITLE
Add `generate_wiki_home_toc`

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -1,0 +1,26 @@
+# Home
+
+- [CHANGELOG](CHANGELOG)
+- [clean_kernel_packages](clean_kernel_packages)
+- [downer](downer)
+- [download_ubuntu_packages](download_ubuntu_packages)
+- [ejectdisk](ejectdisk)
+- [Gemfile](Gemfile)
+- [Gemfile.lock](Gemfile.lock)
+- [generate_wiki_home_toc](generate_wiki_home_toc)
+- [git_purge_empty_branches](git_purge_empty_branches)
+- [install_btrfs_checker](install_btrfs_checker)
+- [install_smart_notifier](install_smart_notifier)
+- [interruptible_job_scheduler.rb](interruptible_job_scheduler.rb)
+- [LICENSE](LICENSE)
+- [ownsync](ownsync)
+- [prettify](prettify)
+- [OpenScripts #](README)
+- [ship_gem](ship_gem)
+- [update_mainline_kernel](update_mainline_kernel)
+- [update_markdown_chapter_references](update_markdown_chapter_references)
+- [update_markdown_toc](update_markdown_toc)
+
+## kernel_packages_maintenance
+
+- [kernel_version.rb](kernel_packages_maintenance/kernel_version.rb)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - concurrency
   - `interruptible_job_scheduler.rb`: a scheduler for interruptible process-based job(s)
 - documents
+  - `generate_wiki_home_toc`: generates the `Home.md` file of a wiki repository, with a table of contents
   - `update_markdown_chapter_references`: generates/updates a Table Of Contents, and navigation links, in a collection of Markdown documents
   - `update_markdown_toc`: generates/updates a Table Of Contents, for a single Markdown document
 - git

--- a/generate_wiki_home_toc
+++ b/generate_wiki_home_toc
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+
+require 'simple_scripting/argv'
+
+class GenerateWikiHomeToc
+  DEFAULT_DIRECTORY = '.'
+  HOME_DIRECTORY_HEADER = "# Home\n\n"
+  HOME_FILE = 'Home.md'
+
+  LONG_HELP = <<~STR
+    Generate the `Home.md` file of a wiki repository, with a table of contents.
+
+    Each directory is an HTML header level, and the files contained are an entry in the section.
+    Files come before directories; for each type, the entries are sorted case-insensitively.
+
+    If a document has an H1 header, it's used as entry description, otherwise, the filename is used (with minor editing).
+  STR
+
+  def execute(directory: DEFAULT_DIRECTORY)
+    Dir.chdir(directory)
+
+    output = HOME_DIRECTORY_HEADER
+    output += print_formatted_directory('.')
+
+    IO.write(HOME_FILE, output)
+  end
+
+  private
+
+  def print_formatted_directory(path)
+    if File.file?(path)
+      if path == "./#{HOME_FILE}"
+        ""
+      else
+        format_file_entry(path)
+      end
+    else
+      output = format_directory_entry(path)
+
+      directory_content = find_and_sort_directory_content(path)
+
+      directory_content.each do |child_path|
+        output += print_formatted_directory(child_path)
+      end
+
+      output
+    end
+  end
+
+  def format_file_entry(file_path)
+    if file_path.end_with?('.md')
+      description = IO.read(file_path)[/^# (.*)/, 1] || File.basename(file_path).chomp('.md')
+    end
+
+    description ||= File.basename(file_path)
+
+    file_url = file_path.sub(%r(^\./), "")
+
+    "- " + "[#{description}](#{file_url})" + "\n"
+  end
+
+  def format_directory_entry(dir_path)
+    parents_count = dir_path.split('/').size
+
+    # Exclude the [wiki] root directory.
+    #
+    if parents_count == 1
+      ""
+    else
+      "\n" + ('#' * parents_count) + " " + File.basename(dir_path) + "\n\n"
+    end
+  end
+
+  def find_and_sort_directory_content(dir_path)
+    Dir["#{dir_path}/*"].sort do |path_1, path_2|
+      if File.file?(path_1) && File.directory?(path_2)
+        -1
+      elsif File.directory?(path_1) && File.file?(path_2)
+        1
+      else
+        File.basename(path_1).downcase <=> File.basename(path_2).downcase
+      end
+    end
+  end
+
+end
+
+if __FILE__ == $0
+  options = SimpleScripting::Argv.decode(
+    '[directory]',
+    long_help: GenerateWikiHomeToc::LONG_HELP
+  ) || exit
+
+  GenerateWikiHomeToc.new.execute(options)
+end

--- a/generate_wiki_home_toc
+++ b/generate_wiki_home_toc
@@ -14,6 +14,8 @@ class GenerateWikiHomeToc
     Files come before directories; for each type, the entries are sorted case-insensitively.
 
     If a document has an H1 header, it's used as entry description, otherwise, the filename is used (with minor editing).
+
+    Links to Markdown documents are changed so that opening them in GitHub will show the HTML page (instead of the raw content).
   STR
 
   def execute(directory: DEFAULT_DIRECTORY)
@@ -48,15 +50,18 @@ class GenerateWikiHomeToc
   end
 
   def format_file_entry(file_path)
+    file_path = file_path.sub(%r(^\./), "")
+
     if file_path.end_with?('.md')
       description = IO.read(file_path)[/^# (.*)/, 1] || File.basename(file_path).chomp('.md')
+      file_path = File.basename(file_path).chomp('.md')
     end
+
+    file_path = file_path.gsub('(', '\(').gsub(')', '\)')
 
     description ||= File.basename(file_path)
 
-    file_url = file_path.sub(%r(^\./), "")
-
-    "- " + "[#{description}](#{file_url})" + "\n"
+    "- " + "[#{description}](#{file_path})" + "\n"
   end
 
   def format_directory_entry(dir_path)


### PR DESCRIPTION
Generates the `Home.md` file of a wiki repository, with a table of contents.