### PR TITLE
Improvements to clean_kernel_packages

### DIFF
--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -58,10 +58,8 @@ class CleanKernelPackages
 
       puts "Removing packages:", *packages_to_remove.map { |package| "- #{package}"}, ""
 
-      unless no_exec
-        remove_packages(packages_to_remove)
-        remove_module_directories(module_directories_to_remove)
-      end
+      remove_packages(packages_to_remove, simulate: no_exec)
+      remove_module_directories(module_directories_to_remove, simulate: no_exec)
     else
       puts "Nothing to remove!"
     end
@@ -135,17 +133,18 @@ class CleanKernelPackages
     module_base_directories.map { |module_directory| File.join(MODULES_DIRECTORY, module_directory) }
   end
 
-  def remove_packages(packages)
-    system("sudo aptitude purge -y #{packages.join(' ')}")
+  def remove_packages(packages, simulate:)
+    simulate_option = "-s" if simulate
+    system("sudo aptitude purge -y #{simulate_option} #{packages.join(' ')}")
   end
 
-  def remove_module_directories(module_directories_to_remove)
+  def remove_module_directories(module_directories_to_remove, simulate:)
     puts "Removing module directories..."
 
     module_directories_to_remove.each do |directory|
       if Dir.exists?(directory)
         puts "- #{directory}"
-        FileUtils.rm_f(directory)
+        FileUtils.rm_f(directory) unless simulate
       end
     end
   end

--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -6,7 +6,34 @@ require 'simple_scripting/argv'
 
 require 'shellwords'
 
+module KernelVersionPackageMatcher
+
+  refine KernelVersion do
+
+    def package_matcher
+      version_pattern = "#{major}\\.#{minor}\\.#{patch}"
+
+      # Aptitude doesn't support `\d` for matching digits.
+      #
+      if ongoing
+        # Example: 4.10.0-14
+        version_pattern + "-#{ongoing}\\b"
+      elsif rc
+        # Example: 4.12.0-041200rc7
+        version_pattern + "-[0-9]{6}rc#{rc}\\b"
+      else
+        # Example: 4.12.0-041200
+        version_pattern + "-[0-9]{6}\\b"
+      end
+    end
+
+  end
+
+end
+
 class CleanKernelPackages
+
+  using KernelVersionPackageMatcher
 
   # include_versions: (Array of KernelVersion) act like the versions passed are installed; it's
   #                   legal, but dangerous, to use this in a regular (non-dry) run.
@@ -78,22 +105,7 @@ class CleanKernelPackages
 
   def find_packages_to_remove(versions)
     package_matchers = versions.map do |version|
-      version_pattern = "#{version.major}\\.#{version.minor}\\.#{version.patch}"
-
-      # Aptitude doesn't support `\d` for matching digits.
-      #
-      if version.ongoing
-        # Example: 4.10.0-14
-        version_pattern << "-#{version.ongoing}\\b"
-      elsif version.rc
-        # Example: 4.12.0-041200rc7
-        version_pattern << "-[0-9]{6}rc#{version.rc}\\b"
-      else
-        # Example: 4.12.0-041200
-        version_pattern << "-[0-9]{6}\\b"
-      end
-
-      "~i^linux-(headers|image|image-extra|modules)-#{version_pattern}".shellescape
+      "~i^linux-(headers|image|image-extra|modules)-#{version.package_matcher}".shellescape
     end.join(' ')
 
     `aptitude search -w 120 #{package_matchers} | cut -c 5- | awk '{print $1}'`.split("\n")

--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -105,7 +105,7 @@ class CleanKernelPackages
 
   def find_packages_to_remove(versions)
     package_matchers = versions.map do |version|
-      "~i^linux-(headers|image|image-extra|modules)-#{version.package_matcher}".shellescape
+      "~i^linux-(headers|image|image-extra|modules|modules-extra)-#{version.package_matcher}".shellescape
     end.join(' ')
 
     `aptitude search -w 120 #{package_matchers} | cut -c 5- | awk '{print $1}'`.split("\n")

--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -4,6 +4,7 @@ require_relative 'kernel_packages_maintenance/kernel_version'
 
 require 'simple_scripting/argv'
 
+require 'fileutils'
 require 'shellwords'
 
 module KernelVersionPackageMatcher
@@ -33,6 +34,8 @@ end
 
 class CleanKernelPackages
 
+  MODULES_DIRECTORY = '/lib/modules'
+
   using KernelVersionPackageMatcher
 
   # include_versions: (Array of KernelVersion) act like the versions passed are installed; it's
@@ -51,10 +54,14 @@ class CleanKernelPackages
 
     if versions_to_remove.size > 0
       packages_to_remove = find_packages_to_remove(versions_to_remove)
+      module_directories_to_remove = find_module_directories_to_remove(versions_to_remove, packages_to_remove)
 
       puts "Removing packages:", *packages_to_remove.map { |package| "- #{package}"}, ""
 
-      remove_packages(packages_to_remove) unless no_exec
+      unless no_exec
+        remove_packages(packages_to_remove)
+        remove_module_directories(module_directories_to_remove)
+      end
     else
       puts "Nothing to remove!"
     end
@@ -111,8 +118,36 @@ class CleanKernelPackages
     `aptitude search -w 120 #{package_matchers} | cut -c 5- | awk '{print $1}'`.split("\n")
   end
 
+  # Sample of returned directory: `/lib/modules/5.0.2-050002-generic`
+  #
+  def find_module_directories_to_remove(versions_to_remove, packages_to_remove)
+    versions_matcher = "(?:" + versions_to_remove.map(&:package_matcher).join('|') + ")"
+
+    # Example of image package names:
+    #
+    # - linux-image-4.15.0-1004-oem
+    # - linux-image-unsigned-5.0.4-050004-generic
+    #
+    # There is always the kernel type suffix, but not always `-unsigned`
+    #
+    module_base_directories = packages_to_remove.join("\n").scan(/^linux-image(?:-unsigned)?-(#{versions_matcher}-\w+)/).flatten
+
+    module_base_directories.map { |module_directory| File.join(MODULES_DIRECTORY, module_directory) }
+  end
+
   def remove_packages(packages)
     system("sudo aptitude purge -y #{packages.join(' ')}")
+  end
+
+  def remove_module_directories(module_directories_to_remove)
+    puts "Removing module directories..."
+
+    module_directories_to_remove.each do |directory|
+      if Dir.exists?(directory)
+        puts "- #{directory}"
+        FileUtils.rm_f(directory)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
- Refactoring: encapsulate kernel version package matching code
- Add `modules-extra` packages to the search for packages to delete
- Remove module directories corresponding to packages removed
- On dry run, use `aptitude` in simulate mode, instead of not running it