### PR TITLE
connect_bt_device: Add support for specifying a master device, and other improvements

### DIFF
--- a/connect_bt_device
+++ b/connect_bt_device
@@ -12,20 +12,20 @@ class ApplicationConfiguration
     devices_configuration = load_devices_configuration
 
     long_help = <<~HELP
-      Connect an audio BT device to the system.
+      Connect an audio BT device (referred as "slave") to the system (referred as "master").
 
       Besides providing a mean to perform the operation, the script helps the user working around the extremely annoying issues with the steaming pile of trash that are Bluetooth, Bluez, and the Ubuntu BT support.
 
-      The combination of the above is very unreliable, and repeated attempts are often necessary to connect a device.
+      The combination of the above is very unreliable, and repeated attempts are often necessary to connect devices.
       In addition, Ubuntu has shipped a broken stack in any version, including any LTS. A specific workaround is provided for working around a bug in Ubuntu 16.04.
 
-      The script will preserve the Bluetooth server devices status, so if BT is disabled, the script will enable it, and disable it on exit.
+      The script will preserve the Bluetooth master devices status, so if BT is disabled, the script will enable it, and disable it on exit.
 
       Switches:
 
-      <device>: Prefix of the device name to connect to.
+      <device>: Prefix of the slave device name to connect.
 
-      Configured devices: #{devices_configuration.keys.map { |name| name + (name == devices_configuration.keys.first ? " (default)" : "") }.join(', ')}
+      Configured slave devices: #{devices_configuration.keys.map { |name| name + (name == devices_configuration.keys.first ? " (default)" : "") }.join(', ')}
 
       Configuration:
 
@@ -39,9 +39,9 @@ class ApplicationConfiguration
       long_help: long_help
     ) || exit
 
-    device_id = find_device_id(devices_configuration, options[:device])
+    slave_device_id = find_slave_device_id(devices_configuration, options[:device])
 
-    [device_id, !!options[:reset_a2dp_profile]]
+    [slave_device_id, !!options[:reset_a2dp_profile]]
   end
 
   private
@@ -56,7 +56,7 @@ class ApplicationConfiguration
     end
   end
 
-  def find_device_id(devices_configuration, device_prefix)
+  def find_slave_device_id(devices_configuration, device_prefix)
     if device_prefix
       # simplified algorithm
       matching_devices = devices_configuration.select { |name, _| name.start_with?(device_prefix) }
@@ -76,24 +76,24 @@ class ApplicationConfiguration
 end # ApplicationConfiguration
 
 module BluetoothDevicesConnectionHelper
-  def connect_audio_device(bt_device_id, pa_card_name, reset_a2dp_profile: false)
+  def connect_audio_slave_device(slave_device_id, pa_card_name, reset_a2dp_profile: false)
     with_bluetooth_ctl do |stdin, stdout|
-      connect_bt_device_loop(bt_device_id, stdin, stdout)
+      connect_slave_device_loop(slave_device_id, stdin, stdout)
 
       if reset_a2dp_profile
         set_pa_card_profile(pa_card_name, 'off')
 
-        disconnect_bt_device_loop(bt_device_id, stdin, stdout)
-        connect_bt_device_loop(bt_device_id, stdin, stdout)
+        disconnect_slave_device_loop(slave_device_id, stdin, stdout)
+        connect_slave_device_loop(slave_device_id, stdin, stdout)
 
         set_pa_card_profile(pa_card_name, 'a2dp_sink')
       end
     end
   end
 
-  def disconnect_device(bt_device_id)
+  def disconnect_slave_device(slave_device_id)
     with_bluetooth_ctl do |stdin, stdout|
-      disconnect_bt_device_loop(bt_device_id, stdin, stdout) if bt_device_connected?(bt_device_id, stdin, stdout)
+      disconnect_slave_device_loop(slave_device_id, stdin, stdout) if slave_device_connected?(slave_device_id, stdin, stdout)
     end
   end
 
@@ -138,9 +138,9 @@ module BluetoothDevicesConnectionHelper
     end
   end
 
-  def connect_bt_device_loop(bt_device_id, bt_ctl_in, bt_ctl_out)
+  def connect_slave_device_loop(slave_device_id, bt_ctl_in, bt_ctl_out)
     loop do
-      bt_ctl_in.puts("connect #{bt_device_id}")
+      bt_ctl_in.puts("connect #{slave_device_id}")
 
       while true
         output = read_available_io(bt_ctl_out)
@@ -158,7 +158,7 @@ module BluetoothDevicesConnectionHelper
         end
       end
     end
-  end # connect_bt_device_loop
+  end # connect_slave_device_loop
 
   def set_pa_card_profile(card, profile)
     puts "Setting PA card profile: #{profile}"
@@ -173,17 +173,17 @@ module BluetoothDevicesConnectionHelper
     puts
   end
 
-  def bt_device_connected?(bt_device_id, bt_ctl_in, bt_ctl_out)
-    bt_ctl_in.puts("info #{bt_device_id}")
+  def slave_device_connected?(slave_device_id, bt_ctl_in, bt_ctl_out)
+    bt_ctl_in.puts("info #{slave_device_id}")
 
     device_information = read_available_io(bt_ctl_out, wait_pattern: /^\s+Connected: \w+$/)
 
     device_information =~ /^\s+Connected: yes$/
   end
 
-  def disconnect_bt_device_loop(bt_device_id, bt_ctl_in, bt_ctl_out)
+  def disconnect_slave_device_loop(slave_device_id, bt_ctl_in, bt_ctl_out)
     loop do
-      bt_ctl_in.puts("disconnect #{bt_device_id}")
+      bt_ctl_in.puts("disconnect #{slave_device_id}")
 
       while true
         output = read_available_io(bt_ctl_out)
@@ -203,29 +203,31 @@ module BluetoothDevicesConnectionHelper
         end
       end
     end
-  end # :disconnect_bt_device_loop
+  end # :disconnect_slave_device_loop
 end # BluetoothDevicesConnectionHelper
 
+# In this context, `device` refers to the master device(s).
+#
 class BluetoothStateManager
-  WIRELESS_DEVICE_BLOCKED = 'blocked'
+  DEVICE_BLOCKED = 'blocked'
 
   include BluetoothDevicesConnectionHelper
 
   def with_bluetooth_enabled
-    wireless_device_start_statuses = find_wireless_device_statuses
+    device_start_statuses = find_device_statuses
 
-    check_device_statuses!(wireless_device_start_statuses)
+    check_device_statuses!(device_start_statuses)
 
-    enable_bluetooth if bt_blocked?(wireless_device_start_statuses)
+    enable_all_devices if devices_blocked?(device_start_statuses)
 
-    bt_device_id = yield
+    slave_device_id = yield
 
-    if bt_blocked?(wireless_device_start_statuses)
+    if devices_blocked?(device_start_statuses)
       pause
 
-      disconnect_device(bt_device_id)
+      disconnect_slave_device(slave_device_id)
 
-      disable_bluetooth
+      disable_all_devices
     end
   end
 
@@ -235,11 +237,11 @@ class BluetoothStateManager
   #
   #   { "device_id" => ("blocked"|"unblocked")}
   #
-  def find_wireless_device_statuses
+  def find_device_statuses
     statuses = `rfkill`.scan(/^ *\d+ bluetooth (\w+) +(\w+)/)
 
     if statuses.empty?
-      raise "No BT wireless devices found!"
+      raise "No master devices found!"
     else
       statuses.to_h
     end
@@ -251,11 +253,11 @@ class BluetoothStateManager
     raise "Mixed statuses found!" if statuses.values.uniq.size != 1
   end
 
-  def bt_blocked?(statuses)
-    statuses.values.uniq == [WIRELESS_DEVICE_BLOCKED]
+  def devices_blocked?(statuses)
+    statuses.values.uniq == [DEVICE_BLOCKED]
   end
 
-  def enable_bluetooth
+  def enable_all_devices
     puts "Enabling BT..."
 
     `rfkill unblock bluetooth`
@@ -266,7 +268,7 @@ class BluetoothStateManager
     gets
   end
 
-  def disable_bluetooth
+  def disable_all_devices
     `rfkill block bluetooth`
   end
 end # BluetoothStateManager
@@ -276,12 +278,12 @@ class BluetoothDevicesConnectionManager
 
   # Returns the device id (mostly, for convenience).
   #
-  def connect(bt_device_id, reset_a2dp_profile: false)
-    bluez_pa_card_name = generate_bluez_pa_card_name(bt_device_id)
+  def connect(slave_device_id, reset_a2dp_profile: false)
+    bluez_pa_card_name = generate_bluez_pa_card_name(slave_device_id)
 
-    connect_audio_device(bt_device_id, bluez_pa_card_name, reset_a2dp_profile: reset_a2dp_profile)
+    connect_audio_slave_device(slave_device_id, bluez_pa_card_name, reset_a2dp_profile: reset_a2dp_profile)
 
-    bt_device_id
+    slave_device_id
   end
 
   private
@@ -290,15 +292,15 @@ class BluetoothDevicesConnectionManager
   #
   #   00:1B:66:7F:E6:F3 -> bluez_card.00_1B_66_7F_E6_F3
   #
-  def generate_bluez_pa_card_name(bt_device_id)
-    "bluez_card." + bt_device_id.gsub(':', '_')
+  def generate_bluez_pa_card_name(slave_device_id)
+    "bluez_card." + slave_device_id.gsub(':', '_')
   end
 end
 
 if __FILE__ == $PROGRAM_NAME
-  device_id, reset_a2dp_profile = ApplicationConfiguration.new.load_arguments_and_configuration
+  slave_device_id, reset_a2dp_profile = ApplicationConfiguration.new.load_arguments_and_configuration
 
   BluetoothStateManager.new.with_bluetooth_enabled do
-    BluetoothDevicesConnectionManager.new.connect(device_id, reset_a2dp_profile: reset_a2dp_profile)
+    BluetoothDevicesConnectionManager.new.connect(slave_device_id, reset_a2dp_profile: reset_a2dp_profile)
   end
 end

--- a/connect_bt_device
+++ b/connect_bt_device
@@ -9,7 +9,7 @@ require 'shellwords'
 
 class ApplicationConfiguration
   def load_arguments_and_configuration
-    devices_configuration = load_devices_configuration
+    master_device, slave_devices = load_and_check_devices_configuration
 
     long_help = <<~HELP
       Connect an audio BT device (referred as "slave") to the system (referred as "master").
@@ -25,12 +25,24 @@ class ApplicationConfiguration
 
       <device>: Prefix of the slave device name to connect.
 
-      Configured slave devices: #{devices_configuration.keys.map { |name| name + (name == devices_configuration.keys.first ? " (default)" : "") }.join(', ')}
+      Configured slave devices: #{slave_devices.keys.map { |name| name + (name == slave_devices.keys.first ? " (default)" : "") }.join(', ')}
 
       Configuration:
 
-      The configuration file ("$HOME/.connect_bt_device") is a typical configfile with each line being `<device_name> = <device_id>`.
-      The first line is the default device.
+      The configuration file ("$HOME/.connect_bt_device") has the following structure:
+
+      ```
+      [master]
+      master_device = <rfkill_device>
+
+      [slaves]
+      <device_name_1> = <device_id_1>
+      <device_name_2> = <device_id_2>
+      ...
+      ```
+
+      The first line in the [slaves] group is the default device.
+      The [master] group is optional; the master device is the `DEVICE` entry of the `rfkill` command.
     HELP
 
     options = SimpleScripting::Argv.decode(
@@ -39,27 +51,32 @@ class ApplicationConfiguration
       long_help: long_help
     ) || exit
 
-    slave_device_id = find_slave_device_id(devices_configuration, options[:device])
+    slave_device_id = find_slave_device_id(slave_devices, options[:device])
 
-    [slave_device_id, !!options[:reset_a2dp_profile]]
+    [master_device, slave_device_id, !!options[:reset_a2dp_profile]]
   end
 
   private
 
-  def load_devices_configuration
-    devices_configuration = SimpleScripting::Configuration.load.to_h.map { |name, id| [name.to_s, id] }.to_h
+  # Returns [slave_devices (Hash), master_device].
+  #
+  def load_and_check_devices_configuration
+    configuration = SimpleScripting::Configuration.load
 
-    if devices_configuration.empty?
-      raise "No devices configured!"
+    if configuration['slaves'].to_h.empty?
+      raise "No slave devices configured!"
     else
-      devices_configuration
+      master_device = configuration['master']&.master_device
+      slave_devices = configuration['slaves'].to_h.map { |name, id| [name.to_s, id] }.to_h
+
+      [master_device, slave_devices]
     end
   end
 
-  def find_slave_device_id(devices_configuration, device_prefix)
+  def find_slave_device_id(slave_devices, device_prefix)
     if device_prefix
       # simplified algorithm
-      matching_devices = devices_configuration.select { |name, _| name.start_with?(device_prefix) }
+      matching_devices = slave_devices.select { |name, _| name.start_with?(device_prefix) }
 
       case matching_devices.size
       when 0
@@ -70,7 +87,7 @@ class ApplicationConfiguration
         raise "Multiple devices found: #{matching_devices.map(&:first)}"
       end
     else
-      devices_configuration.values.first
+      slave_devices.values.first
     end
   end
 end # ApplicationConfiguration
@@ -213,12 +230,12 @@ class BluetoothStateManager
 
   include BluetoothDevicesConnectionHelper
 
-  def with_bluetooth_enabled
-    device_start_statuses = find_device_statuses
+  def with_bluetooth_enabled(device: nil)
+    device_start_statuses = find_device_statuses(only: device)
 
-    check_device_statuses!(device_start_statuses)
+    check_device_statuses!(device_start_statuses) unless device
 
-    enable_all_devices if devices_blocked?(device_start_statuses)
+    enable_devices(device_start_statuses) if devices_blocked?(device_start_statuses)
 
     slave_device_id = yield
 
@@ -227,51 +244,69 @@ class BluetoothStateManager
 
       disconnect_slave_device(slave_device_id)
 
-      disable_all_devices
+      disable_devices(device_start_statuses)
     end
   end
 
   private
 
-  # Returns:
+  # Returns an array of Struct(id, device, blocked).
   #
-  #   { "device_id" => ("blocked"|"unblocked")}
+  #   [id, "device", status (boolean)]
   #
-  def find_device_statuses
-    statuses = `rfkill`.scan(/^ *\d+ bluetooth (\w+) +(\w+)/)
+  def find_device_statuses(only: device)
+    devices_data = `rfkill`.scan(/^ *(\d+) bluetooth (\w+) +(\w+)/)
 
-    if statuses.empty?
-      raise "No master devices found!"
+    devices_data = devices_data.select { |_, device, _| device == only } if only
+
+    if devices_data.empty?
+      if only
+        raise "Device #{only.inspect} not found!"
+      else
+        raise "No master devices found!"
+      end
     else
-      statuses.to_h
+      devices_data.map do |raw_id, device, raw_status|
+        Struct.new(:id, :device, :blocked).new(
+          raw_id.to_i,
+          device,
+          raw_status == DEVICE_BLOCKED,
+        )
+      end
     end
   end
 
   # Allow only all blocked or all unblocked.
   #
-  def check_device_statuses!(statuses)
-    raise "Mixed statuses found: #{statuses}" if statuses.values.uniq.size != 1
+  def check_device_statuses!(device_statuses)
+    if device_statuses.map(&:blocked).uniq.size != 1
+      raise "Mixed statuses found: " + device_statuses.map { |device_status| [device_status.device, device_status.blocked] }.to_h.to_s
+    end
   end
 
-  def devices_blocked?(statuses)
-    statuses.values.uniq == [DEVICE_BLOCKED]
+  def devices_blocked?(device_statuses)
+    device_statuses.map(&:blocked).uniq == [true]
   end
 
-  def enable_all_devices
-    puts "Enabling BT...", ""
+  def enable_devices(device_statuses)
+    puts "Enabling #{device_statuses.map(&:device).join(', ')}...", ""
 
-    `rfkill unblock bluetooth`
+    device_statuses.each do |device|
+      `rfkill unblock #{device.id}`
+    end
   end
 
   def pause
-    print 'Press Enter to disable BT and exit...'
+    print 'Press Enter to disable the master devices and exit...'
     gets
   end
 
-  def disable_all_devices
-    puts "Disabling BT...", ""
+  def disable_devices(device_statuses)
+    puts "Disabling #{device_statuses.map(&:device).join(', ')}...", ""
 
-    `rfkill block bluetooth`
+    device_statuses.each do |device|
+      `rfkill block #{device.id}`
+    end
   end
 end # BluetoothStateManager
 
@@ -302,9 +337,9 @@ class BluetoothDevicesConnectionManager
 end
 
 if __FILE__ == $PROGRAM_NAME
-  slave_device_id, reset_a2dp_profile = ApplicationConfiguration.new.load_arguments_and_configuration
+  master_device, slave_device_id, reset_a2dp_profile = ApplicationConfiguration.new.load_arguments_and_configuration
 
-  BluetoothStateManager.new.with_bluetooth_enabled do
+  BluetoothStateManager.new.with_bluetooth_enabled(device: master_device) do
     BluetoothDevicesConnectionManager.new.connect(slave_device_id, reset_a2dp_profile: reset_a2dp_profile)
   end
 end

--- a/connect_bt_device
+++ b/connect_bt_device
@@ -196,8 +196,8 @@ module BluetoothDevicesConnectionHelper
         when /Successful disconnected/
           puts
           return
-        when /Device [0-9A-F:] not available/
-          raise "Dafuq!!"
+        when /(Device [0-9A-F:] not available)/
+          raise $1
         else
           sleep 0.5
         end
@@ -250,7 +250,7 @@ class BluetoothStateManager
   # Allow only all blocked or all unblocked.
   #
   def check_device_statuses!(statuses)
-    raise "Mixed statuses found!" if statuses.values.uniq.size != 1
+    raise "Mixed statuses found: #{statuses}" if statuses.values.uniq.size != 1
   end
 
   def devices_blocked?(statuses)
@@ -258,7 +258,7 @@ class BluetoothStateManager
   end
 
   def enable_all_devices
-    puts "Enabling BT..."
+    puts "Enabling BT...", ""
 
     `rfkill unblock bluetooth`
   end
@@ -269,6 +269,8 @@ class BluetoothStateManager
   end
 
   def disable_all_devices
+    puts "Disabling BT...", ""
+
     `rfkill block bluetooth`
   end
 end # BluetoothStateManager
@@ -291,6 +293,8 @@ class BluetoothDevicesConnectionManager
   # Example:
   #
   #   00:1B:66:7F:E6:F3 -> bluez_card.00_1B_66_7F_E6_F3
+  #
+  # Names can be manually found via `pactl list cards`.
   #
   def generate_bluez_pa_card_name(slave_device_id)
     "bluez_card." + slave_device_id.gsub(':', '_')


### PR DESCRIPTION
The new support allows the user to specify a master device, in configuration where there are typically multiple master devices, and only one is required for using BT.

Other minor improvements have been done, of cosmetic nature.