### PR TITLE
Add no-poweroff option to ejectdisk

### DIFF
--- a/ejectdisk
+++ b/ejectdisk
@@ -34,7 +34,7 @@ function power_off_device() {
 }
 
 if [[ $# > 1 ]] || [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
-  echo "Usage: ejectdisk [<block_device>]"
+  echo "Usage: $(basename "$0") [<block_device>]"
   echo
   echo "Unmounts and powers off a disk, like the typical desktop environment functionality."
   echo $'The prefix `/dev/` is automatically added, if not present.'

--- a/ejectdisk
+++ b/ejectdisk
@@ -2,24 +2,31 @@
 
 set -o errexit
 
-c_help="Usage: $(basename "$0") [<block_device>]
+c_help="Usage: $(basename "$0") [-n|--no-poweroff] [<block_device>]
 
 Unmounts and powers off a disk, like the typical desktop environment functionality.
 The prefix \`/dev/\` is automatically added, if not present.
 
-If no arguments are passed, all the usb storage devices are ejected."
+If no arguments are passed, all the usb storage devices are ejected.
+
+If the \`no-poweroff\` option is passed, the partitions are unmounted, but the disk is not powered off."
 v_option_device=
+v_option_no_poweroff=
 
 declare -a v_devices
 
 function decode_commandline_arguments {
-  eval set -- "$(getopt --options h --long help -- "$@")"
+  eval set -- "$(getopt --options hn --long help,no-poweroff -- "$@")"
 
   while true; do
     case $1 in
       -h|--help)
         echo "$c_help"
         exit 0
+        ;;
+      -n|--no-poweroff)
+        v_option_no_poweroff=1
+        shift
         ;;
       --)
         shift
@@ -90,6 +97,8 @@ for device in "${v_devices[@]}"; do
   unmount_device_partitions
 done
 
-for device in "${v_devices[@]}"; do
-  power_off_device
-done
+if [[ "$v_option_no_poweroff" != "1" ]]; then
+  for device in "${v_devices[@]}"; do
+    power_off_device
+  done
+fi

--- a/ejectdisk
+++ b/ejectdisk
@@ -2,7 +2,51 @@
 
 set -o errexit
 
+c_help="Usage: $(basename "$0") [<block_device>]
+
+Unmounts and powers off a disk, like the typical desktop environment functionality.
+The prefix \`/dev/\` is automatically added, if not present.
+
+If no arguments are passed, all the usb storage devices are ejected."
+v_option_device=
+
 declare -a v_devices
+
+function decode_commandline_arguments {
+  eval set -- "$(getopt --options h --long help -- "$@")"
+
+  while true; do
+    case $1 in
+      -h|--help)
+        echo "$c_help"
+        exit 0
+        ;;
+      --)
+        shift
+        break
+        ;;
+    esac
+  done
+
+  if [[ $# -gt 1 ]]; then
+    echo "$c_help"
+    exit 1;
+  elif [[ $# == 0 ]]; then
+    v_option_device=
+  else
+    v_option_device="$1"
+  fi
+}
+
+function set_devices {
+  if [[ "$v_option_device" == "" ]]; then
+    find_usb_storage_devices
+  elif [[ $v_option_device =~ ^/dev/ ]]; then
+    v_devices+=("$v_option_device")
+  else
+    v_devices+=("/dev/$v_option_device")
+  fi
+}
 
 function find_usb_storage_devices {
   for device in /sys/block/*; do
@@ -33,32 +77,19 @@ function power_off_device() {
   fi
 }
 
-if [[ $# > 1 ]] || [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
-  echo "Usage: $(basename "$0") [<block_device>]"
-  echo
-  echo "Unmounts and powers off a disk, like the typical desktop environment functionality."
-  echo $'The prefix `/dev/` is automatically added, if not present.'
-  echo
-  echo 'If no arguments are passed, all the usb storage devices are ejected.'
-else
-  if [[ $# == 0 ]]; then
-    find_usb_storage_devices
-  elif [[ $1 =~ ^/dev/ ]]; then
-    v_devices+=("$1")
-  else
-    v_devices+=("/dev/$1")
-  fi
+decode_commandline_arguments "$@"
 
-  # Some peripherals may expose multiple devices (eg. card readers). In this case, when
-  # we power off the first device, the other ones will be implicitly powered off too.
-  # This is possibly ok (unmounting may be implicitly performed), however, for cleanness,
-  # first we umount all, then we (conditionally) power off.
-  #
-  for device in "${v_devices[@]}"; do
-    unmount_device_partitions
-  done
+set_devices
 
-  for device in "${v_devices[@]}"; do
-    power_off_device
-  done
-fi
+# Some peripherals may expose multiple devices (eg. card readers). In this case, when
+# we power off the first device, the other ones will be implicitly powered off too.
+# This is possibly ok (unmounting may be implicitly performed), however, for cleanness,
+# first we umount all, then we (conditionally) power off.
+#
+for device in "${v_devices[@]}"; do
+  unmount_device_partitions
+done
+
+for device in "${v_devices[@]}"; do
+  power_off_device
+done


### PR DESCRIPTION
Useful when one wants to unmount the removable disk partitions, without actually ejecting the disk, so that it can be used (eg. by a virtual machine).