### PR TITLE
Add `encode_to_m4a`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - `prettify`: prettifies files; supports XML and JSON
   - `ship_gem`: ships a gem, performing all the maintenance operation (version increase, tag, build, push, ...)
 - "real-world"
+  - `encode_to_m4a`: encodes and normalizes input files to m4a, using ffmpeg/libsdk_aac
   - `mk_invoice`: prepares a generic (software engineering) invoice in Office Open XML format, using a template, and the data provided in the configuration file
   - `plot_diagram`: plots a diagram from a text file, via GNU Plot (and Ruby),  with better support for batch processing than `plot_2y_diagram`
   - `plot_2y_diagram`: plots a diagram with two y scales from a text file, via GNU Plot (and Ruby)
@@ -37,6 +38,7 @@ I will slowly add remaining or new ones.
 
 Latest additions (not including updates):
 
+- 2019/Sep/03: `encode_to_m4a`
 - 2019/Aug/15: `plot_diagram` and `plot_2y_diagram`
 - 2019/Jul/07: `winetmp`
 - 2019/Apr/30: `spell`

--- a/encode_to_m4a
+++ b/encode_to_m4a
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+help="Usage: $(basename "$0") [-d|--destination <dir>] [-q|--quality <quality>] [-a|--album] <file1> {<fileN>, ...}
+
+Encodes to m4a and applies gain.
+
+\`--album\` applies album gain (otherwise, track gain is applied).
+
+The codec used is libfdk_aac, in VBR, with a default quality of 3 (~110 kbps).
+
+Requires aacgain and a recompiled FFmpeg.
+
+Please note that not all the input/quality combinations work (see https://hydrogenaud.io/index.php/topic,95989.msg817833.html#msg817833).
+"
+
+eval set -- "$(getopt --options hd:q:a --long help,destination:,quality:,album -- "$@")"
+
+destination="."
+quality="3"
+gain_option="-r"
+
+while true ; do
+  case "$1" in
+    -h|--help)
+      echo "$help"
+      exit 0 ;;
+    -d|--destination)
+      destination="$2"
+      shift 2 ;;
+    -q|--quality)
+      quality="$2"
+      shift 2 ;;
+    -a|--album)
+      gain_option="-a"
+      shift ;;
+    --)
+      shift
+      break ;;
+  esac
+done
+
+if [[ $# -eq 0 ]]; then
+  echo "$help"
+  exit 1
+fi
+
+destination_filenames=()
+
+for source_filename in "$@"; do
+  destination_filename="$destination/${source_filename%.*}.m4a"
+
+  ffmpeg -y -i "$source_filename" -vn -c:a libfdk_aac -vbr "$quality" "$destination_filename"
+
+  destination_filenames+=("$destination_filename")
+done
+
+# `-s -r`: ignore ffmpeg written tags, which set the album gain for each track separately.
+#
+aacgain -k "$gain_option" -s r "${destination_filenames[@]}"


### PR DESCRIPTION
Convenient script for converting music files. Uses FFmpeg with libfdk_aac (a high quality encoder).