### PR TITLE
connect_bt_device: disconnect/disable the devices on interrupt

### DIFF
--- a/connect_bt_device
+++ b/connect_bt_device
@@ -235,7 +235,17 @@ class BluetoothStateManager
 
     check_device_statuses!(device_start_statuses) unless device
 
-    enable_devices(device_start_statuses) if devices_blocked?(device_start_statuses)
+    slave_device_id = nil
+
+    if devices_blocked?(device_start_statuses)
+      enable_devices(device_start_statuses)
+
+      trap("INT") do
+        disconnect_slave_device(slave_device_id) if slave_device_id
+
+        disable_devices(device_start_statuses)
+      end
+    end
 
     slave_device_id = yield
 


### PR DESCRIPTION
If something goes wrong (eg. neverending loop), Ctrl+C will disable the devices, resetting to (hopefully) a clean state.