### PR TITLE
connect_bt_device: interrupt handling: fix and make more granular

### DIFF
--- a/connect_bt_device
+++ b/connect_bt_device
@@ -232,21 +232,33 @@ class BluetoothStateManager
 
   include BluetoothDevicesConnectionHelper
 
+  def initialize
+    @initiated_interrupt_exit = false
+  end
+
   def with_bluetooth_enabled(device: nil)
     device_start_statuses = find_device_statuses(only: device)
 
     check_device_statuses!(device_start_statuses) unless device
 
+    enable_devices(device_start_statuses) if devices_blocked?(device_start_statuses)
+
     slave_device_id = nil
 
-    if devices_blocked?(device_start_statuses)
-      enable_devices(device_start_statuses)
+    trap("INT") do
+      puts "Interrupt captured; initiating manual exit..."
 
-      trap("INT") do
-        disconnect_slave_device(slave_device_id) if slave_device_id
+      if !@initiated_interrupt_exit
+        @initiated_interrupt_exit = true
 
-        disable_devices(device_start_statuses)
+        if devices_blocked?(device_start_statuses)
+          disconnect_slave_device(slave_device_id) if slave_device_id
+
+          disable_devices(device_start_statuses)
+        end
       end
+
+      raise Interrupt
     end
 
     slave_device_id = yield

--- a/connect_bt_device
+++ b/connect_bt_device
@@ -233,7 +233,8 @@ class BluetoothStateManager
   include BluetoothDevicesConnectionHelper
 
   def initialize
-    @initiated_interrupt_exit = false
+    @initiated_disconnect_slave = false
+    @initiated_disable_master = false
   end
 
   def with_bluetooth_enabled(device: nil)
@@ -248,14 +249,14 @@ class BluetoothStateManager
     trap("INT") do
       puts "Interrupt captured; initiating manual exit..."
 
-      if !@initiated_interrupt_exit
-        @initiated_interrupt_exit = true
+      if !@initiated_disconnect_slave
+        @initiated_disconnect_slave = true
+        disconnect_slave_device(slave_device_id) if slave_device_id
+      end
 
-        if devices_blocked?(device_start_statuses)
-          disconnect_slave_device(slave_device_id) if slave_device_id
-
-          disable_devices(device_start_statuses)
-        end
+      if !@initiated_disable_master
+        @initiated_disable_master = true
+        disable_devices(device_start_statuses)
       end
 
       raise Interrupt

--- a/connect_bt_device
+++ b/connect_bt_device
@@ -199,6 +199,8 @@ module BluetoothDevicesConnectionHelper
   end
 
   def disconnect_slave_device_loop(slave_device_id, bt_ctl_in, bt_ctl_out)
+    puts "Starting disconnect slave loop..."
+
     loop do
       bt_ctl_in.puts("disconnect #{slave_device_id}")
 


### PR DESCRIPTION
It was broken (exit logic was broken). Also, make it two-steps: separate interruption of disconnection vs. disabling.