### PR TITLE
encode_to_m4a: add directory and copy modes

### DIFF
--- a/encode_to_m4a
+++ b/encode_to_m4a
@@ -3,11 +3,20 @@
 set -o errexit
 set -o nounset
 
-help="Usage: $(basename "$0") [-d|--destination <dir>] [-q|--quality <quality>] [-a|--album] [-r|--remove] <file1> {<fileN>, ...}
+# shellcheck disable=SC2016
+help="Usage: $(basename "$0") [-d|--destination <dir>] [-q|--quality <quality>] [-r|--remove] <input1> {<inputN>, ...}
 
 Encodes to m4a and applies gain.
 
-\`--album\` applies album gain (otherwise, track gain is applied).
+The "'`input`'" values can be either files or directories:
+
+- if they're files: track gain is applied (individually)
+- if they're directories:
+  - album gain is applied, on a directory basis, to lossless files
+  - non-audio files are ignored
+  - subdirectories are not descended
+
+Compressed input audio files which are not flac are copied, without being reencoded.
 
 The codec used is libfdk_aac, in VBR, with a default quality of 3 (~110 kbps).
 
@@ -20,7 +29,6 @@ eval set -- "$(getopt --options hd:q:ar --long help,destination:,quality:,album,
 
 destination="."
 quality="3"
-gain_option="-r"
 remove_file=
 
 while true ; do
@@ -34,9 +42,6 @@ while true ; do
     -q|--quality)
       quality="$2"
       shift 2 ;;
-    -a|--album)
-      gain_option="-a"
-      shift ;;
     -r|--remove)
       remove_file=1
       shift ;;
@@ -51,18 +56,71 @@ if [[ $# -eq 0 ]]; then
   exit 1
 fi
 
-destination_filenames=()
-
 for source_filename in "$@"; do
-  destination_filename="$destination/${source_filename%.*}.m4a"
+  if [[ -f "$source_filename" ]]; then
+    file_mime_type="$(file --mime-type "$source_filename" | grep -oP '\S+/\S+$')"
 
-  ffmpeg -y -i "$source_filename" -vn -c:a libfdk_aac -vbr "$quality" "$destination_filename"
+    case "$file_mime_type" in
+    audio/x-flac | audio/x-wav )
+      destination_filename="$destination/$(basename "${source_filename%.*}.m4a")"
+      ffmpeg -y -i "$source_filename" -vn -c:a libfdk_aac -vbr "$quality" "$destination_filename"
+      ;;
+    video/mp4 | audio/mpeg )
+      destination_filename="$destination/$(basename "$source_filename")"
+      cp "$source_filename" "$destination_filename"
+      ;;
+    * )
+      echo "Unsupported file type for file source: $source_filename"
+      exit 1
+      ;;
+    esac
 
-  destination_filenames+=("$destination_filename")
+    # `-s -r`: ignore ffmpeg written tags, which set the album gain for each track separately.
+    #
+    aacgain -k -r -s r "$destination_filename"
 
-  [[ $remove_file == 1 ]] && rm "$source_filename" || true
+    [[ $remove_file == 1 ]] && rm -f "$source_filename" || true
+  elif [[ -d "$source_filename" ]]; then
+    sub_destination="$destination/$(basename "$source_filename")"
+
+    mkdir -p "$sub_destination"
+
+    encoded_audio_filenames=()
+
+    for sub_source_filename in "$source_filename"/*; do
+      file_mime_type="$(file --mime-type "$sub_source_filename" | grep -oP '\S+/\S+$')"
+
+      case "$file_mime_type" in
+      audio/x-flac | audio/x-wav )
+        sub_destination_filename="$sub_destination/$(basename "${sub_source_filename%.*}.m4a")"
+        ffmpeg -y -i "$sub_source_filename" -vn -c:a libfdk_aac -vbr "$quality" "$sub_destination_filename"
+        encoded_audio_filenames+=("$sub_destination_filename")
+        ;;
+      video/mp4 | audio/mpeg )
+        sub_destination_filename="$sub_destination/$(basename "$sub_source_filename")"
+        cp "$sub_source_filename" "$sub_destination_filename"
+        encoded_audio_filenames+=("$sub_destination_filename")
+        ;;
+      * )
+        if [[ "$file_mime_type" == "audio/"* ]]; then
+          echo "Unsupported audio file!: $sub_source_filename"
+          exit 1
+        elif [[ "$file_mime_type" == "image/"* ]]; then
+          sub_destination_filename="$sub_destination/$(basename "$sub_source_filename")"
+          cp "$sub_source_filename" "$sub_destination_filename"
+        fi
+        # ignore other cases (eg. text files)
+        ;;
+      esac
+    done
+
+    # See `-s -r` note in the previous invocation.
+    #
+    aacgain -k -a -s r "${encoded_audio_filenames[@]}"
+
+    [[ $remove_file == 1 ]] && rm -r "$source_filename" || true
+  else
+    echo "Source type not recognized: $source_filename"
+    exit 1
+  fi
 done
-
-# `-s -r`: ignore ffmpeg written tags, which set the album gain for each track separately.
-#
-aacgain -k "$gain_option" -s r "${destination_filenames[@]}"

--- a/encode_to_m4a
+++ b/encode_to_m4a
@@ -56,58 +56,58 @@ if [[ $# -eq 0 ]]; then
   exit 1
 fi
 
-for source_filename in "$@"; do
-  if [[ -f "$source_filename" ]]; then
-    file_mime_type="$(file --mime-type "$source_filename" | grep -oP '\S+/\S+$')"
+for source_file in "$@"; do
+  if [[ -f "$source_file" ]]; then
+    file_mime_type="$(file --mime-type "$source_file" | grep -oP '\S+/\S+$')"
 
     case "$file_mime_type" in
     audio/x-flac | audio/x-wav )
-      destination_filename="$destination/$(basename "${source_filename%.*}.m4a")"
-      ffmpeg -y -i "$source_filename" -vn -c:a libfdk_aac -vbr "$quality" "$destination_filename"
+      destination_file="$destination/$(basename "${source_file%.*}.m4a")"
+      ffmpeg -y -i "$source_file" -vn -c:a libfdk_aac -vbr "$quality" "$destination_file"
       ;;
     video/mp4 | audio/mpeg )
-      destination_filename="$destination/$(basename "$source_filename")"
-      cp "$source_filename" "$destination_filename"
+      destination_file="$destination/$(basename "$source_file")"
+      cp "$source_file" "$destination_file"
       ;;
     * )
-      echo "Unsupported file type for file source: $source_filename"
+      echo "Unsupported file type for file source: $source_file"
       exit 1
       ;;
     esac
 
     # `-s -r`: ignore ffmpeg written tags, which set the album gain for each track separately.
     #
-    aacgain -k -r -s r "$destination_filename"
+    aacgain -k -r -s r "$destination_file"
 
-    [[ $remove_file == 1 ]] && rm -f "$source_filename" || true
-  elif [[ -d "$source_filename" ]]; then
-    sub_destination="$destination/$(basename "$source_filename")"
+    [[ $remove_file == 1 ]] && rm -f "$source_file" || true
+  elif [[ -d "$source_file" ]]; then
+    destination_subdir="$destination/$(basename "$source_file")"
 
-    mkdir -p "$sub_destination"
+    mkdir -p "$destination_subdir"
 
-    encoded_audio_filenames=()
+    encoded_destination_subfiles=()
 
-    for sub_source_filename in "$source_filename"/*; do
-      file_mime_type="$(file --mime-type "$sub_source_filename" | grep -oP '\S+/\S+$')"
+    for source_subfile in "$source_file"/*; do
+      file_mime_type="$(file --mime-type "$source_subfile" | grep -oP '\S+/\S+$')"
 
       case "$file_mime_type" in
       audio/x-flac | audio/x-wav )
-        sub_destination_filename="$sub_destination/$(basename "${sub_source_filename%.*}.m4a")"
-        ffmpeg -y -i "$sub_source_filename" -vn -c:a libfdk_aac -vbr "$quality" "$sub_destination_filename"
-        encoded_audio_filenames+=("$sub_destination_filename")
+        destination_subfile="$destination_subdir/$(basename "${source_subfile%.*}.m4a")"
+        ffmpeg -y -i "$source_subfile" -vn -c:a libfdk_aac -vbr "$quality" "$destination_subfile"
+        encoded_destination_subfiles+=("$destination_subfile")
         ;;
       video/mp4 | audio/mpeg )
-        sub_destination_filename="$sub_destination/$(basename "$sub_source_filename")"
-        cp "$sub_source_filename" "$sub_destination_filename"
-        encoded_audio_filenames+=("$sub_destination_filename")
+        destination_subfile="$destination_subdir/$(basename "$source_subfile")"
+        cp "$source_subfile" "$destination_subfile"
+        encoded_destination_subfiles+=("$destination_subfile")
         ;;
       * )
         if [[ "$file_mime_type" == "audio/"* ]]; then
-          echo "Unsupported audio file!: $sub_source_filename"
+          echo "Unsupported audio file!: $source_subfile"
           exit 1
         elif [[ "$file_mime_type" == "image/"* ]]; then
-          sub_destination_filename="$sub_destination/$(basename "$sub_source_filename")"
-          cp "$sub_source_filename" "$sub_destination_filename"
+          destination_subfile="$destination_subdir/$(basename "$source_subfile")"
+          cp "$source_subfile" "$destination_subfile"
         fi
         # ignore other cases (eg. text files)
         ;;
@@ -116,11 +116,11 @@ for source_filename in "$@"; do
 
     # See `-s -r` note in the previous invocation.
     #
-    aacgain -k -a -s r "${encoded_audio_filenames[@]}"
+    aacgain -k -a -s r "${encoded_destination_subfiles[@]}"
 
-    [[ $remove_file == 1 ]] && rm -r "$source_filename" || true
+    [[ $remove_file == 1 ]] && rm -r "$source_file" || true
   else
-    echo "Source type not recognized: $source_filename"
+    echo "Source type not recognized: $source_file"
     exit 1
   fi
 done

--- a/encode_to_m4a
+++ b/encode_to_m4a
@@ -62,10 +62,12 @@ for source_file in "$@"; do
 
     case "$file_mime_type" in
     audio/x-flac | audio/x-wav )
+      echo "Encoding $source_file..."
       destination_file="$destination/$(basename "${source_file%.*}.m4a")"
-      ffmpeg -y -i "$source_file" -vn -c:a libfdk_aac -vbr "$quality" "$destination_file"
+      ffmpeg -y -hide_banner -loglevel panic -i "$source_file" -vn -c:a libfdk_aac -vbr "$quality" "$destination_file"
       ;;
     video/mp4 | audio/mpeg )
+      echo "Copying $source_file..."
       destination_file="$destination/$(basename "$source_file")"
       cp "$source_file" "$destination_file"
       ;;
@@ -75,9 +77,11 @@ for source_file in "$@"; do
       ;;
     esac
 
+    echo -n "Normalizing (track) "
+
     # `-s -r`: ignore ffmpeg written tags, which set the album gain for each track separately.
     #
-    aacgain -k -r -s r "$destination_file"
+    aacgain -q -k -r -s r "$destination_file"
 
     [[ $remove_file == 1 ]] && rm -f "$source_file" || true
   elif [[ -d "$source_file" ]]; then
@@ -92,11 +96,13 @@ for source_file in "$@"; do
 
       case "$file_mime_type" in
       audio/x-flac | audio/x-wav )
+        echo "Encoding $source_subfile..."
         destination_subfile="$destination_subdir/$(basename "${source_subfile%.*}.m4a")"
-        ffmpeg -y -i "$source_subfile" -vn -c:a libfdk_aac -vbr "$quality" "$destination_subfile"
+        ffmpeg -y -hide_banner -loglevel panic -i "$source_subfile" -vn -c:a libfdk_aac -vbr "$quality" "$destination_subfile"
         encoded_destination_subfiles+=("$destination_subfile")
         ;;
       video/mp4 | audio/mpeg )
+        echo "Copying $source_subfile..."
         destination_subfile="$destination_subdir/$(basename "$source_subfile")"
         cp "$source_subfile" "$destination_subfile"
         encoded_destination_subfiles+=("$destination_subfile")
@@ -106,6 +112,7 @@ for source_file in "$@"; do
           echo "Unsupported audio file!: $source_subfile"
           exit 1
         elif [[ "$file_mime_type" == "image/"* ]]; then
+          echo "Copying $source_subfile..."
           destination_subfile="$destination_subdir/$(basename "$source_subfile")"
           cp "$source_subfile" "$destination_subfile"
         fi
@@ -114,9 +121,11 @@ for source_file in "$@"; do
       esac
     done
 
+    echo "Normalizing (album) $destination_subdir..."
+
     # See `-s -r` note in the previous invocation.
     #
-    aacgain -k -a -s r "${encoded_destination_subfiles[@]}"
+    aacgain -q -k -a -s r "${encoded_destination_subfiles[@]}"
 
     [[ $remove_file == 1 ]] && rm -r "$source_file" || true
   else


### PR DESCRIPTION
When a source is a directory, its content is encoded and copied into a directory, and normalized as album

Copy mode refers to:

- not encoding lossy files
- copying image files inside directories