### PR TITLE
git_purge_empty_branches: add support for "protected" branches

### DIFF
--- a/git_purge_empty_branches
+++ b/git_purge_empty_branches
@@ -2,6 +2,8 @@
 
 set -o errexit
 
+configuration_file="$HOME/.$(basename "$0")"
+
 if [[ "$#" != 0 ]]; then
   echo 'Usage: git_purge_empty_branches'
   echo
@@ -10,7 +12,15 @@ if [[ "$#" != 0 ]]; then
   echo
   echo "Before performing the purge, the repository is synced, and master is rebased."
   echo
-  echo $'It won\'t delete any branch named `master` or `deployment`'
+  echo "A branch is never deleted if it's called "'`master'" or if it's included in the configfile ($configuration_file)"
+  echo
+  echo "The configfile format is composed of multiple lines in the format "'`<repo_dirname>:<branches_regexp>`'"."
+  echo "Empty lines are ignored."
+  echo
+  echo "Example configfile:"
+  echo
+  echo "  qemu-pinning:^.*-pinning$"
+  echo "  myrepo:^(branch1|branch2)$"
 
   exit 0
 fi
@@ -20,9 +30,17 @@ if [[ $(git status | grep "nothing to commit, working tree clean") == "" ]]; the
   exit 1
 fi
 
-# Fetch all, so that this script can be generally used for syncing the repo.
-git fetch --all --tags --prune
-echo
+declare -A protected_branches
+
+# Make sure the file exists.
+#
+touch "$configuration_file"
+
+while IFS='= ' read -r key value || [ -n "$key" ]; do
+  if [[ "$key" != "" ]]; then
+    protected_branches["$key"]="$value"
+  fi
+done < "$configuration_file"
 
 saved_location=$(git rev-parse --abbrev-ref HEAD)
 
@@ -36,7 +54,13 @@ fi
 git rebase
 echo
 
-for branch in $(git branch | cut -c 3- | egrep -v '^(master|deployment)$'); do
+repo_dirname="$(basename "$(readlink -f .)")"
+protected_branches_pattern="${protected_branches["$repo_dirname"]}"
+
+# If no protected branches are specified, use a phony pattern (will match empty branch names, which are not possible).
+protected_branches_pattern="${protected_branches_pattern:-^$}"
+
+for branch in $(git branch | cut -c 3- | egrep -v '^master$' | egrep -v "$protected_branches_pattern" ); do
   if [[ ! $(git cherry master $branch | grep '^+') ]]; then
     git branch -D $branch
     echo

--- a/git_purge_empty_branches
+++ b/git_purge_empty_branches
@@ -5,7 +5,7 @@ set -o errexit
 configuration_file="$HOME/.$(basename "$0")"
 
 if [[ "$#" != 0 ]]; then
-  echo 'Usage: git_purge_empty_branches'
+  echo "Usage: $(basename "$0")"
   echo
   echo "Delete all the branches (local, and their remote tracked) that haven't any commits that aren't in master."
   echo "Can be run from any branch, but requires a clean tree."
@@ -30,6 +30,8 @@ if [[ $(git status | grep "nothing to commit, working tree clean") == "" ]]; the
   exit 1
 fi
 
+# LOAD PROTECTED BRANCHES ########################
+
 declare -A protected_branches
 
 # Make sure the file exists.
@@ -42,6 +44,8 @@ while IFS='= ' read -r key value || [ -n "$key" ]; do
   fi
 done < "$configuration_file"
 
+# CHECKOUT AND REBASE MASTER #####################
+
 saved_location=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ "$saved_location" != "master" ]]; then
@@ -53,6 +57,8 @@ fi
 
 git rebase
 echo
+
+# DELETE "EMPTY" BRANCHES ########################
 
 repo_dirname="$(basename "$(readlink -f .)")"
 protected_branches_pattern="${protected_branches["$repo_dirname"]}"
@@ -71,6 +77,8 @@ for branch in $(git branch | cut -c 3- | egrep -v '^master$' | egrep -v "$protec
     fi
   fi
 done
+
+# RETURN TO STARTING BRANCH ######################
 
 if [[ "$saved_location" != "master" && $(git cat-file -t "$saved_location" 2> /dev/null) ]]; then
   # The output is very noisy for non-named branches.


### PR DESCRIPTION
Add configuration, to specify branches that must never be deleted.
    
This has a few use cases, for example, a release branch, or cases where a certain version branch has the same HEAD as master.