### PR TITLE
Add 10+ chapters suppor to update_markdown_chapter_references

### DIFF
--- a/update_markdown_chapter_references
+++ b/update_markdown_chapter_references
@@ -81,7 +81,7 @@ class UpdateMarkdownChapterReferences
 
     # Directory is expanded - we don't need to perform any more expansion.
     #
-    chapter_files.sort
+    chapter_files.sort_by { |full_filename| File.basename(full_filename)[/^(\d+)/].to_i }
   end
 
   def has_number?(filename)


### PR DESCRIPTION
In order to support 10+ chapters, the sort on the chapter names can't be lexicographic anymore.