### PR TITLE
plot*diagram: Mad workaround to wait for the diagram window to be closed before exiting

### DIFF
--- a/plot_2y_diagram
+++ b/plot_2y_diagram
@@ -126,6 +126,7 @@ class Plot2yDiagram
       set ytics nomirror
       plot '#{data_file}' using 1:2 #{smooth_option} with linespoints title '#{title1}',\\
            '#{data_file}' using 1:3 #{smooth_option} with linespoints title '#{title2}' axes x1y2
+      pause mouse close
     PLOT
   end
 
@@ -135,7 +136,7 @@ class Plot2yDiagram
     plot_filename = Dir::Tmpname.create(['plot_2y_diagram', '.gp']) { }
     IO.write(plot_filename, commands)
 
-    `gnuplot --persist #{plot_filename}`
+    `echo | gnuplot --persist #{plot_filename}`
   ensure
     File.unlink(plot_filename) if File.exists?(plot_filename)
   end

--- a/plot_diagram
+++ b/plot_diagram
@@ -150,8 +150,10 @@ class PlotDiagram
 
     smooth_option = "smooth sbezier" if smooth
 
+    # See comment in execute_gnuplot_commands.
     commands + <<~PLOT
       plot '#{data_file}' #{using_option} with linespoints #{smooth_option} title '#{title}'
+      pause mouse close
     PLOT
   end
 
@@ -162,7 +164,13 @@ class PlotDiagram
       file.puts(commands)
       file.close
 
-      `gnuplot --persist #{file.path}`
+      # Madness. There is no clean way of waiting for the diagram window to be close before exiting
+      # gnuplot (--persist leaves the diagram window open, but gnuplots exits).
+      # `pause mouse close` does achieve this effect, but requires return to be tapped, after the
+      # window is closed.
+      # Therefore, we use `pause mouse close`, but we send a newline to stdin (!!!).
+      #
+      `echo | gnuplot --persist #{file.path}`
     end
   end
 end


### PR DESCRIPTION
Mad workaround - see comment in the code.