### PR TITLE
Fix two bugs in `mylast`, and apply minor cosmetic improvements

### DIFF
--- a/mylast
+++ b/mylast
@@ -14,24 +14,23 @@
 #
 # Note that batch mode (`--batch`) queries are still logged, so we need to handle this.
 
-# Used in EXPLAIN check
+# Used in the EXPLAIN test.
+#
 shopt -s nocasematch
+
+# In tab-separated mode (not to confuse with table format), the output newlines are escaped, so we
+# unescape them (via sed).
 
 query_thread_id=$(mysql -se "SELECT thread_id FROM mysql.general_log WHERE command_type = 'Query' AND thread_id != CONNECTION_ID()" | tail -n 1)
 
-query=$(mysql -se "SELECT argument FROM mysql.general_log WHERE command_type = 'Query' AND thread_id = $query_thread_id" | tail -n 1)
+query=$(mysql -se "SELECT argument FROM mysql.general_log WHERE command_type = 'Query' AND thread_id = $query_thread_id" | tail -n 1 | sed 's/\\n/\n/g')
 query_used_db=$(mysql -se "SELECT argument FROM mysql.general_log WHERE command_type = 'Init DB' AND thread_id = $query_thread_id" | tail -n 1)
-
-if [[ $query_used_db != "" ]]; then
-  query="USE $query_used_db; $query"
-fi
 
 # The \G modifier is a MySQL client functionality, not stored in the general log. For this reason,
 # we manually don't use table ouput when the explain format is specified.
 #
 if [[ $query == "EXPLAIN FORMAT="* ]]; then
-  # In tab-separated mode, newlines are escaped, so we unescape them.
-  # We also remove the EXPLAIN header.
+  # Remove the EXPLAIN header (`1d`).
   #
   query_output_formatting='1d; s/\\n/\n/g'
 else
@@ -39,6 +38,12 @@ else
   table_option="-t"
 fi
 
-echo "Running query: \"$query\""
+if [[ $query_used_db != "" ]]; then
+  query="USE $query_used_db; $query"
+fi
+
+echo "# Query ##########################"
+echo "$query"
+echo "##################################"
 
 mysql $table_option -e "$query" | sed "$query_output_formatting" | tee >(xsel -ib)


### PR DESCRIPTION
Fixes:

- major: if the query statements were separated by new lines, in some cases (but not all), executing the query would fail
- minor: `USE <schema>` must be added (if required) after testing for `EXPLAIN`, not before, otherwise the test would never pass