### PR TITLE
encode_to_m4a: Add `audo/flac` MIME type support

### DIFF
--- a/encode_to_m4a
+++ b/encode_to_m4a
@@ -109,7 +109,7 @@ function encode_file {
   file_mime_type="$(file --mime-type "$1" | grep -oP '\S+/\S+$')"
 
   case "$file_mime_type" in
-  audio/x-flac | audio/x-wav )
+  audio/flac | audio/x-flac | audio/x-wav )
     echo "Encoding $1..."
 
     destination_file="$destination/$(basename "${1%.*}.m4a")"
@@ -168,7 +168,7 @@ function encode_directory {
     file_mime_type="$(file --mime-type "$source_subfile" | grep -oP '\S+/\S+$')"
 
     case "$file_mime_type" in
-    audio/x-flac | audio/x-wav )
+    audio/flac | audio/x-flac | audio/x-wav )
       echo "Adding $source_subfile to encoding queue..."
 
       destination_subfile="$intermediate_subdir/$(basename "${source_subfile%.*}.m4a")"


### PR DESCRIPTION
After upgrading to Ubuntu 20.04, this is the reported MIME type for FLAC files.